### PR TITLE
fix(tests): remove deprecated overridden event_loop fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,16 +7,6 @@ import pytest
 from async_batcher.batcher import AsyncBatcher
 
 
-@pytest.fixture(scope="session")
-def event_loop():
-    try:
-        loop = asyncio.get_running_loop()
-    except RuntimeError:
-        loop = asyncio.new_event_loop()
-    yield loop
-    loop.close()
-
-
 def pytest_runtest_setup(item):
     def _has_marker(item, marker_name: str) -> bool:
         return len(list(item.iter_markers(name=marker_name))) > 0

--- a/tests/test_batcher.py
+++ b/tests/test_batcher.py
@@ -32,7 +32,7 @@ class CallsMaker:
         self.result = result
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio(scope="session")
 async def test_process_batch(mock_async_batcher):
     result = await asyncio.gather(*[mock_async_batcher.process(item=i) for i in range(10)])
 
@@ -41,7 +41,7 @@ async def test_process_batch(mock_async_batcher):
     assert result == [i * 2 for i in range(10)]
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio(scope="session")
 async def test_process_batch_with_bigger_buffer(mock_async_batcher):
     result = await asyncio.gather(*[mock_async_batcher.process(item=i) for i in range(25)])
 
@@ -52,7 +52,7 @@ async def test_process_batch_with_bigger_buffer(mock_async_batcher):
     assert result == [i * 2 for i in range(25)]
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio(scope="session")
 async def test_process_batch_with_short_buffering_time():
     batcher = MockAsyncBatcher(
         max_batch_size=10,
@@ -80,7 +80,7 @@ async def test_process_batch_with_short_buffering_time():
     await batcher.stop()
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio(scope="session")
 @pytest.mark.parametrize(
     "concurrency, expected_execution_time",
     [
@@ -148,7 +148,7 @@ async def test_concurrent_process_batch(concurrency, expected_execution_time):
     batcher.mock_batch_processor.reset_mock()
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio(scope="session")
 async def test_stop_batcher(mock_async_batcher):
     await asyncio.gather(*[mock_async_batcher.process(item=i) for i in range(10)])
 
@@ -159,7 +159,7 @@ async def test_stop_batcher(mock_async_batcher):
         await mock_async_batcher.process(item=0)
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio(scope="session")
 async def test_force_stop_batcher():
     batcher = SlowAsyncBatcher(
         sleep_time=1,


### PR DESCRIPTION
```
/home/runner/work/async-batcher/async-batcher/.venv/lib/python3.12/site-packages/pytest_asyncio/plugin.py:769: DeprecationWarning: The event_loop fixture provided by pytest-asyncio has been redefined in
  /home/runner/work/async-batcher/async-batcher/tests/conftest.py:10
  Replacing the event_loop fixture with a custom implementation is deprecated
  and will lead to errors in the future.
  If you want to request an asyncio event loop with a scope other than function
  scope, use the "scope" argument to the asyncio mark when marking the tests.
  If you want to return different types of event loops, use the event_loop_policy
  fixture.
```