### PR TITLE
chore: make the classes b/c with 0.1.0

### DIFF
--- a/async_batcher/aws/dynamodb/get.py
+++ b/async_batcher/aws/dynamodb/get.py
@@ -29,14 +29,13 @@ class AsyncDynamoDbGetBatcher(AsyncBatcher[GetItem, dict[str, Any]]):
         endpoint_url: The complete URL to use for the constructed client. This is useful for local testing.
         config: The configuration for the session.
         aioboto3_session: The aioboto3 session to use. If not provided, a new session is created.
-        batch_size: The maximum number of items to process in a single batch. The default is 100 items,
-            which is the maximum number of items that can be processed in a single batch.
-        sleep_time (float, optional): The time to sleep between checking if the result is ready in seconds.
-            Defaults to 0.01. Set it to a value close to the expected time to process a batch
-        buffering_time (float, optional): The time to sleep after processing a batch or checking the buffer
-            in seconds. Defaults to 0.001.
-            You can increase this value if you don't need a low latency, but want to reduce the number of
-            processed batches.
+        max_batch_size (int, optional): The max number of items to process in a batch.The default is 100
+            items, which is the maximum number of items that can be processed in a single batch.
+        max_queue_time (float, optional): The max time for a task to stay in the queue before processing
+            it if the batch is not full and the number of running batches is less than the concurrency.
+            Defaults to 0.01.
+        concurrency (int, optional): The max number of concurrent batches to process. Defaults to 1.
+            If -1, it will process all batches concurrently.
     """
 
     def __init__(
@@ -49,9 +48,13 @@ class AsyncDynamoDbGetBatcher(AsyncBatcher[GetItem, dict[str, Any]]):
         config: AioConfig | None = None,
         aioboto3_session: aioboto3.Session | None = None,
         max_batch_size: int = 100,
-        max_queue_time: float = 0.001,
+        max_queue_time: float = 0.01,
+        concurrency: int = 1,
+        **kwargs,
     ):
-        super().__init__(max_batch_size=max_batch_size, max_queue_time=max_queue_time)
+        super().__init__(
+            max_batch_size=max_batch_size, max_queue_time=max_queue_time, concurrency=concurrency, **kwargs
+        )
         self.region_name = region_name
         self.use_ssl = use_ssl
         self.verify = verify

--- a/async_batcher/aws/dynamodb/write.py
+++ b/async_batcher/aws/dynamodb/write.py
@@ -30,14 +30,13 @@ class AsyncDynamoDbWriteBatcher(AsyncBatcher[WriteOperation, None]):
         endpoint_url: The complete URL to use for the constructed client. This is useful for local testing.
         config: The configuration for the session.
         aioboto3_session: The aioboto3 session to use. If not provided, a new session is created.
-        batch_size: The maximum number of items to process in a single batch. The default is 25 items,
-            which is the maximum number of items that can be processed in a single batch.
-        sleep_time (float, optional): The time to sleep between checking if the result is ready in seconds.
-            Defaults to 0.01. Set it to a value close to the expected time to process a batch
-        buffering_time (float, optional): The time to sleep after processing a batch or checking the buffer
-            in seconds. Defaults to 0.001.
-            You can increase this value if you don't need a low latency, but want to reduce the number of
-            processed batches.
+        max_batch_size (int, optional): The max number of items to process in a batch. The default is 25
+            items, which is the maximum number of items that can be processed in a single batch.
+        max_queue_time (float, optional): The max time for a task to stay in the queue before processing
+            it if the batch is not full and the number of running batches is less than the concurrency.
+            Defaults to 0.01.
+        concurrency (int, optional): The max number of concurrent batches to process.
+            Defaults to 1. If -1, it will process all batches concurrently.
     """
 
     def __init__(
@@ -50,9 +49,13 @@ class AsyncDynamoDbWriteBatcher(AsyncBatcher[WriteOperation, None]):
         config: AioConfig | None = None,
         aioboto3_session: aioboto3.Session | None = None,
         max_batch_size: int = 25,
-        max_queue_time: float = 0.001,
+        max_queue_time: float = 0.01,
+        concurrency: int = 1,
+        **kwargs,
     ):
-        super().__init__(max_batch_size=max_batch_size, max_queue_time=max_queue_time)
+        super().__init__(
+            max_batch_size=max_batch_size, max_queue_time=max_queue_time, concurrency=concurrency, **kwargs
+        )
         self.region_name = region_name
         self.use_ssl = use_ssl
         self.verify = verify

--- a/async_batcher/ml/keras/model.py
+++ b/async_batcher/ml/keras/model.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import asyncio
 from typing import TYPE_CHECKING
 
 from async_batcher.batcher import AsyncBatcher
@@ -17,29 +16,35 @@ class KerasAsyncBatcher(AsyncBatcher):
     Args:
         model: The Keras model to use for prediction.
         executor: The executor to use for running the prediction.
-        batch_size (int, optional): The max number of items to process in a batch. Defaults to -1 (no limit).
-        sleep_time (float, optional): The time to sleep between checking if the result is ready in seconds.
-            Defaults to 0.01. Set it to a value close to the expected time to process a batch
-        buffering_time (float, optional): The time to sleep after processing a batch or checking the buffer
-            in seconds. Defaults to 0.001.
-            You can increase this value if you don't need a low latency, but want to reduce the number of
-            processed batches.
+        max_batch_size (int, optional): The max number of items to process in a batch.
+            Defaults to -1 (no limit).
+        max_queue_time (float, optional): The max time for a task to stay in the queue before
+            processing it if the batch is not full and the number of running batches is less
+            than the concurrency. Defaults to 0.01.
+        concurrency (int, optional): The max number of concurrent batches to process.
+            Defaults to 1. If -1, it will process all batches concurrently.
+        executor (Executor, optional): The executor to use to process the batch.
+            If None, it will use the default asyncio executor. Defaults to None.
     """
 
     def __init__(
         self,
         *,
         model: Model,
-        executor: Executor | None = None,
         max_batch_size: int = -1,
-        max_queue_time: float = 0.001,
+        max_queue_time: float = 0.01,
+        concurrency: int = 1,
+        executor: Executor | None = None,
+        **kwargs,
     ):
-        super().__init__(max_batch_size=max_batch_size, max_queue_time=max_queue_time)
-        self.model = model
-        self.executor = executor
-
-    async def process_batch(self, batch):
-        result = await asyncio.get_event_loop().run_in_executor(
-            self.executor, lambda _batch: self.model.predict(_batch, batch_size=len(_batch)), batch
+        super().__init__(
+            max_batch_size=max_batch_size,
+            max_queue_time=max_queue_time,
+            concurrency=concurrency,
+            executor=executor,
+            **kwargs,
         )
-        return result
+        self.model = model
+
+    def process_batch(self, batch):
+        return self.model.predict(batch, batch_size=len(batch))

--- a/async_batcher/scylladb/update.py
+++ b/async_batcher/scylladb/update.py
@@ -20,7 +20,9 @@ class WriteOperation:
 
 
 class AsyncScyllaDbWriteBatcher(AsyncBatcher[WriteOperation, None]):
-    async def process_batch(self, *, batch: list[WriteOperation]) -> list[None | Exception]:
+    """Batcher for ScyllaDB write operations."""
+
+    def process_batch(self, *, batch: list[WriteOperation]) -> list[None | Exception]:
         results = []
         with BatchQuery() as b:
             for op in batch:


### PR DESCRIPTION
This PR:
- makes the classes backward compatible with 0.1.0 by avoiding failing when the removed parameters are provided
- updates the docstring for all the classes
- switch the classes that use `run_in_executor` to normal function to use the new implicit `run_in_executor` mechanism