### PR TITLE
fix: edge case in py312 for semaphore lock

### DIFF
--- a/async_batcher/batcher.py
+++ b/async_batcher/batcher.py
@@ -181,6 +181,7 @@ class AsyncBatcher(Generic[T, S], abc.ABC):
                         self._running_batches[task_id] = asyncio.get_event_loop().create_task(
                             self._concurrent_batch_run(task_id, batch)
                         )
+                        await asyncio.sleep(0)
                         task_id += 1
                     started_at = None
                 except asyncio.TimeoutError:


### PR DESCRIPTION
In Python 3.12, the created `self._concurrent_batch_run` takes some time, so the next loop acquires the semaphore before the created task (batch_run).

related: #23