### PR TITLE
fix: remove keyword-only constraint on ScyllaDB process_batch param

### DIFF
--- a/async_batcher/scylladb/update.py
+++ b/async_batcher/scylladb/update.py
@@ -22,7 +22,7 @@ class WriteOperation:
 class AsyncScyllaDbWriteBatcher(AsyncBatcher[WriteOperation, None]):
     """Batcher for ScyllaDB write operations."""
 
-    def process_batch(self, *, batch: list[WriteOperation]) -> list[None | Exception]:
+    def process_batch(self, batch: list[WriteOperation]) -> list[None | Exception]:
         results = []
         with BatchQuery() as b:
             for op in batch:


### PR DESCRIPTION
## Summary
- `AsyncScyllaDbWriteBatcher.process_batch` uses `*, batch` (keyword-only), but the base class `_batch_run` calls it via `run_in_executor` for sync implementations, which passes args **positionally**
- `run_in_executor` cannot pass keyword arguments, so this would raise a `TypeError` at runtime
- Fix: remove the `*` to make `batch` a regular positional parameter, consistent with all other `process_batch` implementations

## Test plan
- [ ] Existing ScyllaDB integration tests pass
- [ ] Verify `run_in_executor` path works with the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)