### PR TITLE
fix: use remaining time budget instead of full max_queue_time in batch fill

### DIFF
--- a/async_batcher/batcher.py
+++ b/async_batcher/batcher.py
@@ -122,7 +122,7 @@ class AsyncBatcher(Generic[T, S], abc.ABC):
             try:
                 max_wait = self.max_queue_time - (asyncio.get_running_loop().time() - started_at)
                 if max_wait > 0:
-                    item = await asyncio.wait_for(self._queue.get(), timeout=self.max_queue_time)
+                    item = await asyncio.wait_for(self._queue.get(), timeout=max_wait)
                 else:
                     item = self._queue.get_nowait()
                 batch.append(item)


### PR DESCRIPTION
## Summary
- `_fill_batch_from_queue` computes `max_wait` (remaining time budget) but then passes `self.max_queue_time` (the full duration) to `asyncio.wait_for`
- This causes batches to wait up to ~2x the configured `max_queue_time` before being flushed
- Fix: pass `max_wait` instead of `self.max_queue_time`

## Test plan
- [ ] Existing unit tests pass (particularly `test_process_batch_with_short_buffering_time`)
- [ ] Timing-sensitive concurrency tests still within expected bounds

🤖 Generated with [Claude Code](https://claude.com/claude-code)