### PR TITLE
fix: remove empty returning() call on insert statement

### DIFF
--- a/async_batcher/sqlalchemy/write.py
+++ b/async_batcher/sqlalchemy/write.py
@@ -43,7 +43,7 @@ class AsyncSqlalchemyWriteBatcher(AsyncBatcher[dict[str, Any], None]):
         session: AsyncSession
         async with self.async_session_maker() as session:
             if self.operation == "insert":
-                statement = insert(self.model).returning()
+                statement = insert(self.model)
             elif self.operation == "update":
                 statement = update(self.model)
             if self.returning:


### PR DESCRIPTION
## Summary
- `insert(self.model).returning()` was called with no arguments when `self.returning` is `None`
- This produces an invalid/unexpected SQLAlchemy statement
- The `returning()` clause is correctly applied later only when `self.returning` is set, but the empty `.returning()` call on line 46 was always executed for inserts
- Fix: build `insert(self.model)` without the empty `.returning()`, consistent with the `update` branch

## Test plan
- [ ] Existing SQLAlchemy unit tests pass (SQLite)
- [ ] Integration tests with PostgreSQL pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)