### PR TITLE
fix: use put_nowait to avoid race condition on queue full check

### DIFF
--- a/async_batcher/batcher.py
+++ b/async_batcher/batcher.py
@@ -105,9 +105,10 @@ class AsyncBatcher(Generic[T, S], abc.ABC):
             self._current_task = asyncio.get_running_loop().create_task(self.run())
         logging.debug(item)
         future = asyncio.get_running_loop().create_future()
-        if self._queue.full():
+        try:
+            self._queue.put_nowait(self.QueueItem(item, future))
+        except asyncio.QueueFull:
             raise QueueFullException("The queue is full, cannot process more items at the moment.")
-        await self._queue.put(self.QueueItem(item, future))
         await future
         return future.result()
 


### PR DESCRIPTION
## Summary
- The previous code checked `queue.full()` then called `await queue.put()` as separate operations
- Between the check and the put, another coroutine could add an item (after yielding at `await`), causing the put to block unexpectedly or the check to be stale
- Fix: use `put_nowait()` and catch `asyncio.QueueFull` to make the check-and-put atomic

## Test plan
- [ ] `test_max_queue_size` still passes
- [ ] All unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)