### PR TITLE
fix: move _running_batches cleanup to finally block in _batch_run

### DIFF
--- a/async_batcher/batcher.py
+++ b/async_batcher/batcher.py
@@ -156,9 +156,10 @@ class AsyncBatcher(Generic[T, S], abc.ABC):
                     q_item.future.set_exception(result)
                 else:
                     q_item.future.set_result(result)
-        elapsed_time = asyncio.get_event_loop().time() - started_at
-        self.logger.debug(f"Processed batch of {len(batch)} elements" f" in {elapsed_time} seconds.")
-        self._running_batches.pop(task_id)
+        finally:
+            elapsed_time = asyncio.get_event_loop().time() - started_at
+            self.logger.debug(f"Processed batch of {len(batch)} elements" f" in {elapsed_time} seconds.")
+            self._running_batches.pop(task_id, None)
 
     async def _concurrent_batch_run(self, task_id: int, batch: list[QueueItem]):
         async with self._concurrency_semaphore:


### PR DESCRIPTION
## Summary
- If `set_exception` or `set_result` raises (e.g., future already cancelled), `task_id` was never removed from `_running_batches`, causing a memory leak
- Moved cleanup (`pop` + debug log) into a `finally` block to ensure it always executes
- Use `pop(task_id, None)` to avoid `KeyError` if the task was already removed

## Test plan
- [ ] All existing unit tests pass
- [ ] Force stop test still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)