### PR TITLE
fix: use instance logger instead of root logger in process()

### DIFF
--- a/async_batcher/batcher.py
+++ b/async_batcher/batcher.py
@@ -103,7 +103,7 @@ class AsyncBatcher(Generic[T, S], abc.ABC):
             raise RuntimeError("Batcher is stopped")
         if self._current_task is None:
             self._current_task = asyncio.get_running_loop().create_task(self.run())
-        logging.debug(item)
+        self.logger.debug("Processing item: %s", item)
         future = asyncio.get_running_loop().create_future()
         if self._queue.full():
             raise QueueFullException("The queue is full, cannot process more items at the moment.")


### PR DESCRIPTION
## Summary
- `process()` used `logging.debug(item)` which logs to the **root logger** and eagerly evaluates the item repr
- Changed to `self.logger.debug("Processing item: %s", item)` for:
  - Consistent use of the class-level logger (`async_batcher.batcher`)
  - Lazy string formatting (avoids repr cost when debug is disabled)

## Test plan
- [ ] All existing unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)