### PR TITLE
chore: replace deprecated get_event_loop() with get_running_loop()

### DIFF
--- a/async_batcher/batcher.py
+++ b/async_batcher/batcher.py
@@ -117,7 +117,7 @@ class AsyncBatcher(Generic[T, S], abc.ABC):
         except asyncio.TimeoutError:
             return []
         if started_at is None:
-            started_at = asyncio.get_event_loop().time()
+            started_at = asyncio.get_running_loop().time()
         while True:
             try:
                 max_wait = self.max_queue_time - (asyncio.get_running_loop().time() - started_at)
@@ -133,13 +133,13 @@ class AsyncBatcher(Generic[T, S], abc.ABC):
         return batch
 
     async def _batch_run(self, task_id: int, batch: list[QueueItem]):
-        started_at = asyncio.get_event_loop().time()
+        started_at = asyncio.get_running_loop().time()
         try:
             batch_items = [q_item.item for q_item in batch]
             if asyncio.iscoroutinefunction(self.process_batch):
                 results = await self.process_batch(batch=batch_items)
             else:
-                results = await asyncio.get_event_loop().run_in_executor(
+                results = await asyncio.get_running_loop().run_in_executor(
                     self.executor, self.process_batch, batch_items
                 )
             if results is None:
@@ -156,7 +156,7 @@ class AsyncBatcher(Generic[T, S], abc.ABC):
                     q_item.future.set_exception(result)
                 else:
                     q_item.future.set_result(result)
-        elapsed_time = asyncio.get_event_loop().time() - started_at
+        elapsed_time = asyncio.get_running_loop().time() - started_at
         self.logger.debug(f"Processed batch of {len(batch)} elements" f" in {elapsed_time} seconds.")
         self._running_batches.pop(task_id)
 
@@ -172,7 +172,7 @@ class AsyncBatcher(Generic[T, S], abc.ABC):
             started_at = None
             while not self._should_stop():
                 if started_at is None:
-                    started_at = asyncio.get_event_loop().time()
+                    started_at = asyncio.get_running_loop().time()
                 semaphore_acquired = False
                 try:
                     # to check if the batcher should stop, we raise a timeout after 1 second
@@ -185,7 +185,7 @@ class AsyncBatcher(Generic[T, S], abc.ABC):
                     )
                     if batch:
                         # create a new task to process the batch
-                        self._running_batches[task_id] = asyncio.get_event_loop().create_task(
+                        self._running_batches[task_id] = asyncio.get_running_loop().create_task(
                             self._concurrent_batch_run(task_id, batch)
                         )
                         await asyncio.sleep(0)
@@ -200,7 +200,7 @@ class AsyncBatcher(Generic[T, S], abc.ABC):
             while not self._should_stop():
                 batch = await self._fill_batch_from_queue(started_at=None)
                 if batch:
-                    self._running_batches[task_id] = asyncio.get_event_loop().create_task(
+                    self._running_batches[task_id] = asyncio.get_running_loop().create_task(
                         self._batch_run(task_id, batch)
                     )
                     task_id += 1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,13 +38,13 @@ class SlowAsyncBatcher(MockAsyncBatcher):
 
 
 @pytest.fixture(scope="function")
-def mock_async_batcher():
+async def mock_async_batcher():
     batcher = MockAsyncBatcher(
         max_batch_size=10,
         max_queue_time=0.01,
     )
     yield batcher
-    asyncio.get_event_loop().run_until_complete(batcher.stop())
+    await batcher.stop()
     batcher.mock_batch_processor.reset_mock()
 
 

--- a/tests/test_batcher.py
+++ b/tests/test_batcher.py
@@ -121,12 +121,12 @@ async def test_concurrent_process_batch(concurrency, expected_execution_time):
         concurrency=concurrency,
     )
     batcher.mock_batch_processor.reset_mock()
-    started_at = asyncio.get_event_loop().time()
+    started_at = asyncio.get_running_loop().time()
     calls_maker1 = CallsMaker(batcher, 0, 0, 5)
     calls_maker2 = CallsMaker(batcher, 0.25, 5, 20)
     calls_maker3 = CallsMaker(batcher, 0.4, 20, 30)
     await asyncio.gather(calls_maker1.arun(), calls_maker2.arun(), calls_maker3.arun())
-    ended_at = asyncio.get_event_loop().time()
+    ended_at = asyncio.get_running_loop().time()
 
     # we add 0.4 seconds to the expected time to account for the sleep time
     # for Python 3.12, we need to add 1 second to the expected time because there


### PR DESCRIPTION
## Summary
- `asyncio.get_event_loop()` emits deprecation warnings in Python 3.12+ when no current event loop is set
- All usages are within async contexts where a loop is guaranteed to be running, so `get_running_loop()` is the correct replacement
- Replaced 7 occurrences in `batcher.py`, 2 in `test_batcher.py`
- Converted `mock_async_batcher` fixture from sync to async to avoid `run_until_complete()`

## Test plan
- [ ] All unit tests pass on Python 3.10, 3.11, 3.12
- [ ] No deprecation warnings in test output

🤖 Generated with [Claude Code](https://claude.com/claude-code)