### PR TITLE
feat: allow batcher restart after stop()

### DIFF
--- a/async_batcher/batcher.py
+++ b/async_batcher/batcher.py
@@ -100,7 +100,8 @@ class AsyncBatcher(Generic[T, S], abc.ABC):
             S: The result of processing the item.
         """
         if self._stop.is_set():
-            raise RuntimeError("Batcher is stopped")
+            self._stop.clear()
+            self._current_task = None
         if self._current_task is None:
             self._current_task = asyncio.get_running_loop().create_task(self.run())
         logging.debug(item)

--- a/tests/test_batcher.py
+++ b/tests/test_batcher.py
@@ -162,8 +162,18 @@ async def test_stop_batcher(mock_async_batcher):
     assert await mock_async_batcher.is_running()
     await mock_async_batcher.stop()
     assert not await mock_async_batcher.is_running()
-    with pytest.raises(RuntimeError):
-        await mock_async_batcher.process(item=0)
+
+
+@pytest.mark.asyncio(scope="session")
+async def test_restart_batcher_after_stop(mock_async_batcher):
+    await asyncio.gather(*[mock_async_batcher.process(item=i) for i in range(10)])
+    await mock_async_batcher.stop()
+    assert not await mock_async_batcher.is_running()
+
+    # batcher should restart automatically on next process() call
+    result = await asyncio.gather(*[mock_async_batcher.process(item=i) for i in range(5)])
+    assert await mock_async_batcher.is_running()
+    assert result == [i * 2 for i in range(5)]
 
 
 @pytest.mark.asyncio(scope="session")


### PR DESCRIPTION
## Summary
- Previously, once `stop()` was called, the batcher permanently refused new items with `RuntimeError("Batcher is stopped")`
- Now `process()` clears the stop event and restarts the `run()` loop automatically, making the batcher reusable
- Added `test_restart_batcher_after_stop` test to verify the behavior
- Removed the `RuntimeError` assertion from `test_stop_batcher` since the batcher now restarts instead

## Test plan
- [ ] New `test_restart_batcher_after_stop` passes
- [ ] Existing `test_stop_batcher` passes (minus the RuntimeError check)
- [ ] All other unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)