### PR TITLE
test: make mock_batch_processor an instance variable

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,7 +21,9 @@ def pytest_runtest_setup(item):
 
 
 class MockAsyncBatcher(AsyncBatcher):
-    mock_batch_processor = mock.AsyncMock(side_effect=lambda batch: [i * 2 for i in batch])
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.mock_batch_processor = mock.AsyncMock(side_effect=lambda batch: [i * 2 for i in batch])
 
     async def process_batch(self, *args, **kwargs):
         return await self.mock_batch_processor(*args, **kwargs)


### PR DESCRIPTION
## Summary
- `mock_batch_processor` was a **class variable** shared across all `MockAsyncBatcher` instances
- If `reset_mock()` was missed between tests, state from one test could leak into another
- Moved to `__init__` so each instance gets its own isolated mock

## Test plan
- [ ] All unit tests pass
- [ ] No cross-test interference

🤖 Generated with [Claude Code](https://claude.com/claude-code)