### PR TITLE
feat: add public exports to async_batcher __init__.py

### DIFF
--- a/async_batcher/__init__.py
+++ b/async_batcher/__init__.py
@@ -1,1 +1,10 @@
+from __future__ import annotations
 
+from async_batcher.batcher import AsyncBatcher
+from async_batcher.exceptions import AsyncBatchException, QueueFullException
+
+__all__ = [
+    "AsyncBatcher",
+    "AsyncBatchException",
+    "QueueFullException",
+]


### PR DESCRIPTION
## Summary
- `async_batcher/__init__.py` was empty — users had to import from deep submodules (e.g., `from async_batcher.batcher import AsyncBatcher`)
- Now exports core classes from the top-level package:
  - `AsyncBatcher`
  - `AsyncBatchException`
  - `QueueFullException`
- Enables: `from async_batcher import AsyncBatcher`

## Test plan
- [ ] All existing imports still work
- [ ] `from async_batcher import AsyncBatcher` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)